### PR TITLE
fix(pkg): support node engines greater than 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "validate": "npm run lint && npm run test"
  },
  "engines": {
-  "node": "8.x"
+  "node": "> 8"
  }
 }


### PR DESCRIPTION
Hi and thanks for this package :)

This package supports node engines upper than 8.x but because of engine constraint, yarn does not allow installing package. This PR changes the constraint